### PR TITLE
Update Example to No Longer Pass ASAuthorizationAnchor

### DIFF
--- a/example-ios/ViewControllers/LoginViewController.swift
+++ b/example-ios/ViewControllers/LoginViewController.swift
@@ -63,10 +63,9 @@ final class LoginViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         if #available(iOS 16.0, *) {
-            guard let window = self.view.window else { fatalError("The view was not in the app's view hierarchy!") }
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 Task {
-                    try await PassageAuth.beginAutoFill(anchor: window, onSuccess: self.onLoginSuccess, onError: self.onLoginError, onCancel: nil)
+                    try await PassageAuth.beginAutoFill(onSuccess: self.onLoginSuccess, onError: self.onLoginError, onCancel: nil)
                 }
             }
         }

--- a/example-ios/ViewControllers/WelcomeViewController.swift
+++ b/example-ios/ViewControllers/WelcomeViewController.swift
@@ -22,7 +22,6 @@ final class WelcomeViewController: UIViewController {
     
     @IBAction func onPressLogout(_ sender: Any) {
         Task {
-            try? await PassageAuth.signOut()
             let _ = navigationController?.popToRootViewController(animated: false)
         }
     }


### PR DESCRIPTION
### Description
A companion PR to: 
https://github.com/passageidentity/passage-ios/pull/20

The passage-ios API removed the unnecessary use of a presentation anchor, so update the example to reflect that.

Also cleaned up the unnecessary use of signOut which is only used with refresh tokens (and the token in this app is just in-memory anyways).

### Testing
Verified with local build that autofill is still functioning as expected.