### PR TITLE
Add OTP as a fallback option.

### DIFF
--- a/example-ios.xcodeproj/project.pbxproj
+++ b/example-ios.xcodeproj/project.pbxproj
@@ -7,8 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DF7F888A29E5EC8200015EB6 /* PasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7F888929E5EC8200015EB6 /* PasscodeViewController.swift */; };
+		DFB2534C2A1EDA4000DA0EFB /* Passage in Frameworks */ = {isa = PBXBuildFile; productRef = DFB2534B2A1EDA4000DA0EFB /* Passage */; };
 		F02DE7E028CE7EAD003B6D42 /* Passage.plist in Resources */ = {isa = PBXBuildFile; fileRef = F02DE7DF28CE7EAD003B6D42 /* Passage.plist */; };
-		F02DE7E328CE88B5003B6D42 /* Passage in Frameworks */ = {isa = PBXBuildFile; productRef = F02DE7E228CE88B5003B6D42 /* Passage */; };
 		F0512CF128C28D0A00911094 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0512CF028C28D0A00911094 /* User.swift */; };
 		F088C0D828BBCC5700A004EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F088C0D728BBCC5700A004EE /* AppDelegate.swift */; };
 		F088C0DA28BBCC5700A004EE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F088C0D928BBCC5700A004EE /* SceneDelegate.swift */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		DF7F888929E5EC8200015EB6 /* PasscodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeViewController.swift; sourceTree = "<group>"; };
 		F02DE7DF28CE7EAD003B6D42 /* Passage.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Passage.plist; sourceTree = "<group>"; };
 		F0512CF028C28D0A00911094 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		F0512CF728C2A64800911094 /* example-ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "example-ios.entitlements"; sourceTree = "<group>"; };
@@ -43,7 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F02DE7E328CE88B5003B6D42 /* Passage in Frameworks */,
+				DFB2534C2A1EDA4000DA0EFB /* Passage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +92,7 @@
 				F088C0ED28BBD76200A004EE /* WelcomeViewController.swift */,
 				F088C0F028BBDB9600A004EE /* SavePasskeyViewController.swift */,
 				F0512CF028C28D0A00911094 /* User.swift */,
+				DF7F888929E5EC8200015EB6 /* PasscodeViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -111,7 +114,7 @@
 			);
 			name = "example-ios";
 			packageProductDependencies = (
-				F02DE7E228CE88B5003B6D42 /* Passage */,
+				DFB2534B2A1EDA4000DA0EFB /* Passage */,
 			);
 			productName = "example-ios";
 			productReference = F088C0D428BBCC5700A004EE /* example-ios.app */;
@@ -142,7 +145,7 @@
 			);
 			mainGroup = F088C0CB28BBCC5700A004EE;
 			packageReferences = (
-				F02DE7E128CE88B5003B6D42 /* XCRemoteSwiftPackageReference "passage-ios" */,
+				DFB2534A2A1EDA4000DA0EFB /* XCRemoteSwiftPackageReference "passage-ios" */,
 			);
 			productRefGroup = F088C0D528BBCC5700A004EE /* Products */;
 			projectDirPath = "";
@@ -172,6 +175,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DF7F888A29E5EC8200015EB6 /* PasscodeViewController.swift in Sources */,
 				F088C0DC28BBCC5700A004EE /* LoginViewController.swift in Sources */,
 				F088C0EE28BBD76200A004EE /* WelcomeViewController.swift in Sources */,
 				F088C0D828BBCC5700A004EE /* AppDelegate.swift in Sources */,
@@ -402,20 +406,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F02DE7E128CE88B5003B6D42 /* XCRemoteSwiftPackageReference "passage-ios" */ = {
+		DFB2534A2A1EDA4000DA0EFB /* XCRemoteSwiftPackageReference "passage-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/passageidentity/passage-ios#installation";
+			repositoryURL = "https://github.com/passageidentity/passage-ios";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F02DE7E228CE88B5003B6D42 /* Passage */ = {
+		DFB2534B2A1EDA4000DA0EFB /* Passage */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F02DE7E128CE88B5003B6D42 /* XCRemoteSwiftPackageReference "passage-ios" */;
+			package = DFB2534A2A1EDA4000DA0EFB /* XCRemoteSwiftPackageReference "passage-ios" */;
 			productName = Passage;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/example-ios/Base.lproj/Main.storyboard
+++ b/example-ios/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Bhd-xj-WTR">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Bhd-xj-WTR">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -358,6 +358,93 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SFc-lf-pWX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="820" y="781"/>
+        </scene>
+        <!--Passcode View Controller-->
+        <scene sceneID="Urq-2M-Odb">
+            <objects>
+                <viewController storyboardIdentifier="PasscodeViewController" id="x3a-HE-odT" customClass="PasscodeViewController" customModule="example_ios" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Aot-sH-uxz">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ywz-wa-Npq">
+                                <rect key="frame" x="32" y="79" width="326" height="282.33333333333331"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter code" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KS6-tM-keU">
+                                        <rect key="frame" x="0.0" y="0.0" width="326" height="26.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A one time code has been sent." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ekx-EL-gQp">
+                                        <rect key="frame" x="0.0" y="54.333333333333343" width="326" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qjf-tF-5H2">
+                                        <rect key="frame" x="0.0" y="99.333333333333343" width="326" height="48"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="center" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="000000" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BBh-Ci-GTT">
+                                                <rect key="frame" x="103" y="0.0" width="120" height="48"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="120" id="hAB-Az-2Pk"/>
+                                                    <constraint firstAttribute="height" constant="48" id="hpU-lb-64M"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done" textContentType="one-time-code"/>
+                                            </textField>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="BBh-Ci-GTT" secondAttribute="bottom" id="0XH-mV-qzy"/>
+                                            <constraint firstItem="BBh-Ci-GTT" firstAttribute="centerX" secondItem="Qjf-tF-5H2" secondAttribute="centerX" id="4jU-1y-Tq5"/>
+                                            <constraint firstItem="BBh-Ci-GTT" firstAttribute="top" secondItem="Qjf-tF-5H2" secondAttribute="top" id="FfF-FY-L9J"/>
+                                        </constraints>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bxa-uQ-C9d">
+                                        <rect key="frame" x="0.0" y="175.33333333333334" width="326" height="48"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="48" id="F8A-4T-kR5"/>
+                                        </constraints>
+                                        <color key="tintColor" name="AccentColor"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="filled" title="Continue" cornerStyle="capsule">
+                                            <fontDescription key="titleFontDescription" type="boldSystem" pointSize="16"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="onPressButton:" destination="x3a-HE-odT" eventType="touchUpInside" id="HwS-TH-bzS"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2u4-Zq-82q">
+                                        <rect key="frame" x="0.0" y="251.33333333333331" width="326" height="31"/>
+                                        <color key="tintColor" name="AccentColor"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Resend code">
+                                            <fontDescription key="titleFontDescription" type="boldSystem" pointSize="14"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="onPressResendButton:" destination="x3a-HE-odT" eventType="touchUpInside" id="AsH-9R-Zf8"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="CRl-yb-8aO"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ywz-wa-Npq" firstAttribute="leading" secondItem="CRl-yb-8aO" secondAttribute="leading" constant="32" id="bBw-gM-C6S"/>
+                            <constraint firstItem="CRl-yb-8aO" firstAttribute="trailing" secondItem="Ywz-wa-Npq" secondAttribute="trailing" constant="32" id="rSl-G3-q1M"/>
+                            <constraint firstItem="Ywz-wa-Npq" firstAttribute="top" secondItem="CRl-yb-8aO" secondAttribute="top" constant="32" id="tCd-us-OqF"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="textField" destination="BBh-Ci-GTT" id="7vj-k8-Hy5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="l6U-zh-vQd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="22" y="1549"/>
         </scene>
     </scenes>
     <resources>

--- a/example-ios/ViewControllers/CheckEmailViewController.swift
+++ b/example-ios/ViewControllers/CheckEmailViewController.swift
@@ -53,7 +53,7 @@ final class CheckEmailViewController: UIViewController {
     
     func handleMagicLink(_ magicLink: String) {
         Task {
-            guard let token = try? await PassageAuth.magicLinkActivate(userMagicLink: magicLink).auth_token else {
+            guard let token = try? await PassageAuth.magicLinkActivate(userMagicLink: magicLink).authToken else {
                 return
             }
             pushWelcomeViewController(token: token)
@@ -63,8 +63,7 @@ final class CheckEmailViewController: UIViewController {
     private func checkMagicLinkStatus() {
         guard let magicLinkId else { return }
         Task {
-            guard let authResult = try? await PassageAuth.getMagicLinkStatus(id: magicLinkId),
-                  let token = authResult.auth_token else {
+            guard let token = try? await PassageAuth.getMagicLinkStatus(id: magicLinkId).authToken else {
                 return
             }
             pushWelcomeViewController(token: token)

--- a/example-ios/ViewControllers/LoginViewController.swift
+++ b/example-ios/ViewControllers/LoginViewController.swift
@@ -140,6 +140,8 @@ final class LoginViewController: UIViewController {
         let passcodeViewController = storyboard?
             .instantiateViewController(withIdentifier: "PasscodeViewController") as! PasscodeViewController
         passcodeViewController.oneTimePasscodeId = oneTimePasscodeId
+        passcodeViewController.email = email
+        passcodeViewController.isShowingRegister = isShowingRegister
         navigationController?.pushViewController(passcodeViewController, animated: true)
     }
     

--- a/example-ios/ViewControllers/PasscodeViewController.swift
+++ b/example-ios/ViewControllers/PasscodeViewController.swift
@@ -1,0 +1,26 @@
+//
+//  PasscodeViewController.swift
+//  example-ios
+//
+
+import Passage
+import UIKit
+
+final class PasscodeViewController: UIViewController {
+    
+    @IBOutlet weak var textField: UITextField!
+    @IBAction func onPressButton(_ sender: Any) {
+        guard let oneTimePasscodeId, let otp = textField.text else { return }
+        Task {
+            let result = try? await PassageAuth.oneTimePasscodeActivate(otp: otp, otpId: oneTimePasscodeId)
+            if let token = result?.authToken {
+                let ac = UIAlertController(title: "Passcode verified 😎", message: "Token: \(token)", preferredStyle: .alert)
+                ac.addAction(UIAlertAction(title: "Okay", style: .cancel))
+                present(ac, animated: true)
+            }
+        }
+    }
+    
+    var oneTimePasscodeId: String? = nil
+    
+}

--- a/example-ios/ViewControllers/PasscodeViewController.swift
+++ b/example-ios/ViewControllers/PasscodeViewController.swift
@@ -1,26 +1,53 @@
-//
-//  PasscodeViewController.swift
-//  example-ios
-//
-
 import Passage
 import UIKit
 
 final class PasscodeViewController: UIViewController {
     
+    var oneTimePasscodeId: String? = nil
+    var email: String? = nil
+    var isShowingRegister = false
+    
     @IBOutlet weak var textField: UITextField!
+    
     @IBAction func onPressButton(_ sender: Any) {
         guard let oneTimePasscodeId, let otp = textField.text else { return }
         Task {
             let result = try? await PassageAuth.oneTimePasscodeActivate(otp: otp, otpId: oneTimePasscodeId)
-            if let token = result?.authToken {
-                let ac = UIAlertController(title: "Passcode verified 😎", message: "Token: \(token)", preferredStyle: .alert)
-                ac.addAction(UIAlertAction(title: "Okay", style: .cancel))
-                present(ac, animated: true)
+            guard let token = result?.authToken else {
+                let alert = UIAlertController(title: "Invalid passcode", message: "Please try again.", preferredStyle: .alert)
+                let action = UIAlertAction(title: "Okay", style: .default, handler: nil)
+                alert.addAction(action)
+                present(alert, animated: true, completion: nil)
+                return
             }
+            pushWelcomeViewController(token: token)
         }
     }
     
-    var oneTimePasscodeId: String? = nil
+    @IBAction func onPressResendButton(_ sender: Any) {
+        guard let email else { return }
+        Task {
+            if isShowingRegister {
+                oneTimePasscodeId = try? await PassageAuth.newRegisterOneTimePasscode(identifier: email).id
+            } else {
+                oneTimePasscodeId = try? await PassageAuth.newLoginOneTimePasscode(identifier: email).id
+            }
+            let alert = UIAlertController(title: "Passcode resent", message: nil, preferredStyle: .alert)
+            let action = UIAlertAction(title: "Okay", style: .default, handler: nil)
+            alert.addAction(action)
+            present(alert, animated: true, completion: nil)
+        }
+    }
+    
+    private func pushWelcomeViewController(token: String) {
+        let welcomeViewController = storyboard?
+            .instantiateViewController(withIdentifier: "WelcomeViewController") as! WelcomeViewController
+        welcomeViewController.token = token
+        if !isShowingRegister, #available(iOS 16.0, *) {
+            // If existing user logs in for first time on this device using OTP, allow to add Passkey
+            welcomeViewController.showAddDeviceButton = true
+        }
+        navigationController?.pushViewController(welcomeViewController, animated: true)
+    }
     
 }

--- a/example-ios/ViewControllers/SavePasskeyViewController.swift
+++ b/example-ios/ViewControllers/SavePasskeyViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 final class SavePasskeyViewController: UIViewController {
     
     var token: String? = nil
-    var passageUser: PassageUserDetails? = nil
+    var passageUser: PassageUserInfo? = nil
     
     @IBOutlet weak var emailLabel: UILabel!
     

--- a/example-ios/ViewControllers/WelcomeViewController.swift
+++ b/example-ios/ViewControllers/WelcomeViewController.swift
@@ -10,7 +10,7 @@ final class WelcomeViewController: UIViewController {
     
     var token: String? = nil
     var showAddDeviceButton = false
-    var passageUser: PassageUserDetails? = nil
+    var passageUser: PassageUserInfo? = nil
     
     @IBOutlet weak var emailLabel: UILabel!
     @IBOutlet weak var addDeviceButton: UIButton!
@@ -51,7 +51,7 @@ final class WelcomeViewController: UIViewController {
     private func showDeviceNames(userDevices: [DeviceInfo]) {
         for device in userDevices {
             let label = UILabel()
-            label.text = device.friendly_name
+            label.text = device.friendlyName
             label.textAlignment = .center
             label.font = label.font.withSize(14)
             userDevicesStackView.addArrangedSubview(label)


### PR DESCRIPTION
This PR includes:
* Updated `passage-ios` to 1.1.0 and handled renamed properties
* Implementation of One Time Passcode fallback method in `PasscodeViewController`

<img src="https://github.com/passageidentity/example-ios/assets/16176400/938f8340-aa27-4c23-8aff-2ee2a69df801" width=40% /> <img src="https://github.com/passageidentity/example-ios/assets/16176400/41924afb-9223-4654-b4d4-3b819e9b00a2" width=40% />

